### PR TITLE
Troubleshoot CI rebuild process

### DIFF
--- a/.github/workflows/update-calendar-entries.yml
+++ b/.github/workflows/update-calendar-entries.yml
@@ -25,6 +25,8 @@ jobs:
       run: |
         python tools/data_mirror.py
         cat src/calendarEntries.json
+    - name: Debugging with tmate
+      uses: mxschmitt/action-tmate@v3.1
     - name: Rebuild if changes has been detected
       run: |
         bash tools/rebuild_onchanges.sh

--- a/.github/workflows/update-calendar-entries.yml
+++ b/.github/workflows/update-calendar-entries.yml
@@ -25,8 +25,6 @@ jobs:
       run: |
         python tools/data_mirror.py
         cat src/calendarEntries.json
-    - name: Debugging with tmate
-      uses: mxschmitt/action-tmate@v3.1
     - name: Rebuild if changes has been detected
       run: |
         bash tools/rebuild_onchanges.sh

--- a/tools/rebuild_onchanges.sh
+++ b/tools/rebuild_onchanges.sh
@@ -2,6 +2,8 @@
 # Detect changes to trigger a new rebuild
 
 # something_changed=`git diff-index --exit-code --ignore-submodules HEAD`
+echo `git status --porcelain | wc -l`
+git status
 something_changed=`git status --porcelain | wc -l`
 if [ "$something_changed" -gt 0 ]; then
     echo >&2 "Something changed in $local_ref, rebuilding app"

--- a/tools/rebuild_onchanges.sh
+++ b/tools/rebuild_onchanges.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Detect changes to trigger a new rebuild
 
-something_changed=`git diff-index --exit-code --ignore-submodules HEAD`
-if [ -n "$something_changed" ]
-then
+# something_changed=`git diff-index --exit-code --ignore-submodules HEAD`
+something_changed=`git status --porcelain | wc -l`
+if [ "$something_changed" -gt 0 ]; then
     echo >&2 "Something changed in $local_ref, rebuilding app"
     yarn && yarn build
 fi


### PR DESCRIPTION
The way that we inspected if there are new changes pending to be commited / stagged are not working as expected, and each CI run enforces an un-needed rebuild of the app.

This fixes it ensuring that changes has been identified correctly and the rebuild is just requested when new entries has been fetched.